### PR TITLE
legacy field validation errors on fresh installs

### DIFF
--- a/ckanext/usmetadata/plugin.py
+++ b/ckanext/usmetadata/plugin.py
@@ -142,13 +142,10 @@ expanded_metadata = (
     {'id': 'related_documents', 'validators': [v.String(max=2100)]},
     {'id': 'conforms_to', 'validators': [v.URL(add_http=True), v.String(max=2100)]},
     {'id': 'homepage_url', 'validators': [v.URL(add_http=True), v.String(max=2100)]},
-    {'id': 'rss_feed', 'validators': [v.String(max=2100)]},
     {'id': 'system_of_records', 'validators': [v.URL(add_http=True), v.String(max=2100)]},
-    {'id': 'system_of_records_none_related_to_this_dataset', 'validators': [v.String(max=2100)]},
     {'id': 'primary_it_investment_uii', 'validators': [v.Regex(
         r'^[0-9]{3}-[0-9]{9}$'
     )]},
-    {'id': 'webservice', 'validators': [v.String(max=300)]},
     {'id': 'publisher_1', 'validators': [v.String(max=300)]},
     {'id': 'publisher_2', 'validators': [v.String(max=300)]},
     {'id': 'publisher_3', 'validators': [v.String(max=300)]},
@@ -160,7 +157,6 @@ expanded_metadata = (
 required_if_applicable_metadata = (
     {'id': 'data_dictionary', 'validators': [v.URL(add_http=True), v.String(max=2100)]},
     {'id': 'data_dictionary_type', 'validators': [v.String(max=2100)]},
-    {'id': 'endpoint', 'validators': [v.String(max=2100)]},
     {'id': 'spatial', 'validators': [v.String(max=500)]},
     {'id': 'temporal', 'validators': [v.Regex(
         r'^[\-\dTWRZP/YMWDHMS:\+]{3,}/[\-\dTWRZP/YMWDHMS:\+]{3,}$'


### PR DESCRIPTION
Keeping validations on legacy fields cause errors on fresh installs.
This commit removes endpoint, rss_feed, web service and
system_of_records_non_related_to_this_dataset validations.

More details on errors:
2015-01-19 15:06:31,524 DEBUG [ckanext.usmetadata.plugin]
_create_package_schema called
Error - <class 'ckan.lib.navl.dictization_functions.Invalid'>:
u'Missing value'
…
File
'/usr/lib/ckan/default/src/ckan/ckan/lib/navl/dictization_functions.py',
 line 13 in __str__
  raise Invalid(_('Missing value'))

removing these validation checks removes this error.