### PR TITLE
[WIP] Remove 'Manage' button

### DIFF
--- a/ckanext/usmetadata/templates/package/read_base.html
+++ b/ckanext/usmetadata/templates/package/read_base.html
@@ -3,8 +3,9 @@
 {% block subtitle %}{{ h.usmetadata_filter(super(), '') }}{% endblock %}
 
 {% block content_action %}
+    {{ super() }}
+
     {% if h.check_access('package_update', {'id':pkg.id }) %}
-        {% link_for _('Manage'), controller='package', action='edit', id=pkg.name, class_='btn', icon='wrench' %}
         {% link_for _('Clone'), controller='ckanext.usmetadata.plugin:CloneController', action='clone_dataset_metadata', id=pkg.name, class_='btn', icon='wrench' %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Includes:

* Removal of "Manage" button from package page so we can add a new button that goes to new metadata form.
* Adds "super" tag so that we can add more components into the block from another extension.